### PR TITLE
fix. user api 리프레시, 액세스 토큰 수정

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -68,11 +68,9 @@ export class UsersController {
       data.nick_name,
       data.password,
     );
-    const authentication = await this.userService.login(
-      data.email,
-      data.password,
-    );
-    response.cookie('AccessToken', 'Bearer ' + authentication.access_Token);
+
+    response.cookie('AccessToken', 'Bearer ' + newUser.access_Token);
+    response.cookie('RefreshToken', 'Bearer ' + newUser.refresh_Token);
     return response.status(201).send('회원가입 완료');
   }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -27,7 +27,7 @@ export class UsersService {
   async getUserInfo(email: string) {
     return await this.userRepository.findOne({
       where: { email },
-      select: ['id', 'email', 'password', 'nick_name'],
+      select: ['id', 'email', 'password', 'nick_name', 'refresh_token'],
     });
   }
 
@@ -96,29 +96,26 @@ export class UsersService {
         `e메일이 이미 사용 중입니다. email: ${email}`,
       );
     }
-
-    // 지금 테스트때문에 막아놨음
-    // 이메일이 인증된 이메일인지 확인한다.
-    // if (!isEmailVerified['email'] === true) {
-    //   console.log('이메일확인용 콘솔', isEmailVerified);
-    //   throw new ConflictException(`인증된 이메일이 아닙니다.`);
-    // }
-
     const insertResult = await this.userRepository.insert({
       is_admin,
       email,
       nick_name,
       password: hashedPassword,
     });
-
-    const newUser = {
+    console.log('insertResult', insertResult);
+    const payload = {
       id: insertResult.identifiers[0].id,
-      is_admin,
-      email,
-      nick_name,
     };
-
-    return newUser;
+    const accessToken = await this.jwtService.signAsync(payload, {
+      expiresIn: '30m',
+    });
+    const refreshToken = await this.jwtService.signAsync(payload, {
+      expiresIn: '7d',
+    });
+    await this.userRepository.update(insertResult.identifiers[0].id, {
+      refresh_token: refreshToken,
+    });
+    return { access_Token: accessToken, refresh_Token: refreshToken };
   }
 
   async login(email: string, password: string) {
@@ -146,10 +143,7 @@ export class UsersService {
       const accessToken = await this.jwtService.signAsync(payload, {
         expiresIn: '30m',
       });
-
-      const refreshToken = await this.jwtService.signAsync(payload, {
-        expiresIn: '7d',
-      });
+      const refreshToken = userConfirm.refresh_token;
 
       return { access_Token: accessToken, refresh_Token: refreshToken };
     } catch (error) {


### PR DESCRIPTION
회원가입 시 액세스, 리프레시 토큰 발급받도록 수정
리프레시 토큰은 회원가입이 성공 시 DB에 저장될 수 있도록 수정

로그인 시 저장된 리프레시 토큰을 가져와서 cookie로 보내주도록 수정